### PR TITLE
Fixed incorrect image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [GoReportCard Widget]: https://goreportcard.com/badge/github.com/supergiant/capacity
 [GoReportCard URL]: https://goreportcard.com/report/github.com/supergiant/capacity
 
-<img src="https://s3.amazonaws.com/supergiant-docs-assets/control_light.svg">
+<img src="https://s3.amazonaws.com/supergiant-docs-assets/capacity_light.svg">
 
 ---
 


### PR DESCRIPTION
I put the wrong image in the last PR. I put in the banner for SG Control, not SG Capacity... 😅 This fixes that!