### PR TITLE
SC-26 ⁃ Move capacity models to the api package

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"errors"
+	"time"
+)
+
+// Worker is an abstraction used by kubescaler to manage cluster capacity.
+// It contains data from a (virtual) machine and a kubernetes node running on it.
+type Worker struct {
+	// ClusterName is a kubernetes cluster name.
+	ClusterName string `json:"clusterName"`
+	// MachineID is a unique id of the provider's virtual machine.
+	// required: true
+	MachineID string `json:"machineID"`
+	// MachineName is a human-readable name of virtual machine.
+	MachineName string `json:"machineName"`
+	// MachineType is type of virtual machine (eg. 't2.micro' for AWS).
+	MachineType string `json:"machineType"`
+	// MachineState represent a virtual machine state.
+	MachineState string `json:"machineState"`
+	// CreationTimestamp is a timestamp representing a time when this machine was created.
+	CreationTimestamp time.Time `json:"creationTimestamp"`
+	// Reserved is a parameter that is used to prevent downscaling of the worker.
+	Reserved bool `json:"reserved"`
+	// NodeName represents a name of the kubernetes node that runs on top of that machine.
+	NodeName string `json:"nodeName"`
+	// NodeLabels represents a labels of the kubernetes node that runs on top of that machine.
+	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
+}
+
+type WorkerList struct {
+	Items []*Worker `json:"items"`
+}
+
+type Config struct {
+	ClusterName     string            `json:"clusterName"`
+	ProviderName    string            `json:"providerName"`
+	Provider        map[string]string `json:"provider"`
+	Paused          *bool             `json:"paused,omitempty"`
+	PauseLock       bool              `json:"pauseLock"`
+	ScanInterval    string            `json:"scanInterval"`
+	WorkersCountMin int               `json:"workersCountMin"`
+	WorkersCountMax int               `json:"workersCountMax"`
+	MachineTypes    []string          `json:"machineTypes"`
+	// TODO: this is hardcoded and isn't used at the moment
+	MaxMachineProvisionTime string            `json:"maxMachineProvisionTime"`
+	IgnoredNodeLabels       map[string]string `json:"ignoredNodeLabels"`
+	NewNodeTimeBuffer       int               `json:"newNodeTimeBuffer"`
+
+	// These is a SG1.0 UserData template parameters
+	// TODO: add an explicit struct for it or use a map for dynamic values
+	MasterPrivateAddr string `json:"masterPrivateAddr"`
+	KubeAPIHost       string `json:"kubeAPIHost"`
+	KubeAPIPort       string `json:"kubeAPIPort"`
+	KubeAPIUser       string `json:"kubeAPIUser"`
+	KubeAPIPassword   string `json:"kubeAPIPassword"`
+	SSHPubKey         string `json:"sshPubKey"`
+}
+
+func (c Config) Validate() error {
+	// TODO: pass it with a pointer or use the ConfigRequest struct for patches.
+	if c.WorkersCountMin < 0 {
+		return errors.New("WorkersCountMin can't be negative")
+	}
+	if c.WorkersCountMax < 0 {
+		return errors.New("WorkersCountMax can't be negative")
+	}
+	return nil
+}

--- a/pkg/capacityserver/handlers/swagger/typesv1.go
+++ b/pkg/capacityserver/handlers/swagger/typesv1.go
@@ -1,8 +1,7 @@
 package swagger
 
 import (
-	"github.com/supergiant/capacity/pkg/kubescaler"
-	"github.com/supergiant/capacity/pkg/kubescaler/workers"
+	"github.com/supergiant/capacity/pkg/api"
 	"github.com/supergiant/capacity/pkg/provider"
 )
 
@@ -10,7 +9,7 @@ import (
 // swagger:response configResponse
 type configResponse struct {
 	// in:body
-	Config *kubescaler.Config `json:"config"`
+	Config *api.Config `json:"config"`
 }
 
 // machineTypesListResponse contains a list of workers.
@@ -24,14 +23,14 @@ type machineTypesListResponse struct {
 // swagger:response workerResponse
 type workerResponse struct {
 	// in:body
-	Worker *workers.Worker `json:"worker"`
+	Worker *api.Worker `json:"worker"`
 }
 
 // workerListResponse contains a list of workers.
 // swagger:response workerListResponse
 type workerListResponse struct {
 	// in:body
-	WorkerList *workers.WorkerList `json:"workerList"`
+	WorkerList *api.WorkerList `json:"workerList"`
 }
 
 // machineIDParam is used to identify a worker.

--- a/pkg/capacityserver/handlers/v1/config.go
+++ b/pkg/capacityserver/handlers/v1/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/supergiant/capacity/pkg/api"
 	"github.com/supergiant/capacity/pkg/kubescaler"
 	"github.com/supergiant/capacity/pkg/log"
 )
@@ -64,7 +65,7 @@ func (h *configHandler) patchConfig(w http.ResponseWriter, r *http.Request) {
 	//     Responses:
 	//     200: configResponse
 
-	patch := kubescaler.Config{}
+	patch := api.Config{}
 	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
 		log.Errorf("handler: kubescaler: patch config: decode: %v", err)
 		w.WriteHeader(http.StatusBadRequest)

--- a/pkg/capacityserver/handlers/v1/workers.go
+++ b/pkg/capacityserver/handlers/v1/workers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 
+	"github.com/supergiant/capacity/pkg/api"
 	"github.com/supergiant/capacity/pkg/kubescaler/workers"
 	"github.com/supergiant/capacity/pkg/log"
 )
@@ -63,7 +64,7 @@ func (h *workersHandler) createWorker(w http.ResponseWriter, r *http.Request) {
 	//     201: workerResponse
 
 	var err error
-	worker := &workers.Worker{}
+	worker := &api.Worker{}
 	if err = json.NewDecoder(r.Body).Decode(worker); err != nil {
 		log.Errorf("handler: kubescaler: create worker: decode: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -168,7 +169,7 @@ func (h *workersHandler) updateWorker(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var err error
-	worker := &workers.Worker{}
+	worker := &api.Worker{}
 	if err = json.NewDecoder(r.Body).Decode(&worker); err != nil {
 		log.Errorf("handler: kubescaler: patch worker: decode: %v", err)
 		w.WriteHeader(http.StatusBadRequest)

--- a/pkg/kubescaler/kubescaler.go
+++ b/pkg/kubescaler/kubescaler.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/supergiant/capacity/pkg/api"
 	"github.com/supergiant/capacity/pkg/kubernetes/config"
 	"github.com/supergiant/capacity/pkg/kubernetes/filters"
 	"github.com/supergiant/capacity/pkg/kubernetes/listers"
@@ -234,7 +235,7 @@ type resources struct {
 	allPods         []*corev1.Pod
 	scheduledPods   []*corev1.Pod
 	unscheduledPods []*corev1.Pod
-	workerList      *workers.WorkerList
+	workerList      *api.WorkerList
 }
 
 func (s *Kubescaler) getResources() (*resources, error) {
@@ -263,7 +264,7 @@ func (s *Kubescaler) getResources() (*resources, error) {
 	}, nil
 }
 
-func (s *Kubescaler) checkWorkers(workerList *workers.WorkerList, currentTime time.Time) ([]string, []string) {
+func (s *Kubescaler) checkWorkers(workerList *api.WorkerList, currentTime time.Time) ([]string, []string) {
 	//failedMachines:
 	//	- state == 'running'
 	//	- running >= maxProvisionTime
@@ -325,7 +326,7 @@ func findMachine(name string, machineTypes []*provider.MachineType) *provider.Ma
 	return nil
 }
 
-func isMaster(w *workers.Worker) bool {
+func isMaster(w *api.Worker) bool {
 	// TODO: use role tags for it in SG2.0
 	return strings.Contains(strings.ToLower(w.MachineName), "master")
 }

--- a/pkg/kubescaler/scaledown_test.go
+++ b/pkg/kubescaler/scaledown_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/supergiant/capacity/pkg/kubescaler/workers"
+	"github.com/supergiant/capacity/pkg/api"
 	"github.com/supergiant/capacity/pkg/kubescaler/workers/fake"
 	"github.com/supergiant/capacity/pkg/persistentfile/file"
 )
@@ -18,15 +18,15 @@ import (
 func TestKubescalerScaleDown(t *testing.T) {
 	tcs := []struct {
 		pods            []*corev1.Pod
-		workerList      *workers.WorkerList
+		workerList      *api.WorkerList
 		allowedMachines []string
 		providerErr     error
 		expectedErr     error
 	}{
 		{
 			pods: []*corev1.Pod{&podNew, &podStandAlone, &podWithRequests},
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{NodeName: NodeReadyName},
 				},
 			},
@@ -34,8 +34,8 @@ func TestKubescalerScaleDown(t *testing.T) {
 		},
 		{
 			pods: []*corev1.Pod{&podWithHugeRequests, &podStandAlone},
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{NodeName: NodeReadyName},
 					{NodeName: NodeScaleDownName},
 				},
@@ -44,8 +44,8 @@ func TestKubescalerScaleDown(t *testing.T) {
 		},
 		{
 			pods: []*corev1.Pod{&podWithHugeRequests, &podWithRequests},
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{NodeName: NodeReadyName},
 					{NodeName: NodeScaleDownName},
 				},
@@ -54,8 +54,8 @@ func TestKubescalerScaleDown(t *testing.T) {
 		},
 		{
 			pods: []*corev1.Pod{&podWithHugeRequests, &podWithRequests},
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{NodeName: NodeReadyName},
 					{NodeName: NodeScaleDownName},
 				},
@@ -74,7 +74,7 @@ func TestKubescalerScaleDown(t *testing.T) {
 			ConfigManager: &ConfigManager{
 				file: f,
 				mu:   sync.RWMutex{},
-				conf: Config{
+				conf: api.Config{
 					MachineTypes: tc.allowedMachines,
 				},
 			},
@@ -132,55 +132,55 @@ func TestFilterDaemonSetPods(t *testing.T) {
 
 func TestGetEmpty(t *testing.T) {
 	tcs := []struct {
-		workerList *workers.WorkerList
+		workerList *api.WorkerList
 		nodePods   map[string][]string
-		expected   []*workers.Worker
+		expected   []*api.Worker
 	}{
 		{ // TC#1
 		},
 		{ // TC#2
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{
 						NodeName: NodeReadyName,
 					},
 				},
 			},
-			expected: []*workers.Worker{
+			expected: []*api.Worker{
 				{
 					NodeName: NodeReadyName,
 				},
 			},
 		},
 		{ // TC#3
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{
 						NodeName: NodeReadyName,
 					},
 				},
 			},
 			nodePods: map[string][]string{NodeReadyName: {"pod"}},
-			expected: []*workers.Worker{},
+			expected: []*api.Worker{},
 		},
 		{ // TC#4
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{
 						NodeName: NodeReadyName,
 					},
 				},
 			},
 			nodePods: map[string][]string{NodeReadyName: {}},
-			expected: []*workers.Worker{
+			expected: []*api.Worker{
 				{
 					NodeName: NodeReadyName,
 				},
 			},
 		},
 		{ // TC#4
-			workerList: &workers.WorkerList{
-				Items: []*workers.Worker{
+			workerList: &api.WorkerList{
+				Items: []*api.Worker{
 					{
 						NodeName: NodeReadyName,
 					},
@@ -190,7 +190,7 @@ func TestGetEmpty(t *testing.T) {
 				},
 			},
 			nodePods: map[string][]string{NodeReadyName: {"pod"}, NodeScaleDownName: {}},
-			expected: []*workers.Worker{
+			expected: []*api.Worker{
 				{
 					NodeName: NodeScaleDownName,
 				},

--- a/pkg/kubescaler/scaleup_test.go
+++ b/pkg/kubescaler/scaleup_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/supergiant/capacity/pkg/api"
 	"github.com/supergiant/capacity/pkg/kubescaler/workers/fake"
 	"github.com/supergiant/capacity/pkg/persistentfile/file"
 	"github.com/supergiant/capacity/pkg/provider"
@@ -212,7 +213,7 @@ func TestKubescalerScaleUp(t *testing.T) {
 			ConfigManager: &ConfigManager{
 				file: f,
 				mu:   sync.RWMutex{},
-				conf: Config{
+				conf: api.Config{
 					MachineTypes: tc.allowedMachines,
 				},
 			},

--- a/pkg/kubescaler/workers/fake/worker.go
+++ b/pkg/kubescaler/workers/fake/worker.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/supergiant/capacity/pkg/api"
 	"github.com/supergiant/capacity/pkg/kubescaler/workers"
 	"github.com/supergiant/capacity/pkg/provider"
 )
@@ -43,8 +44,8 @@ func (m *Manager) MachineTypes() []*provider.MachineType {
 	}
 }
 
-func (m *Manager) CreateWorker(ctx context.Context, mtype string) (*workers.Worker, error) {
-	return &workers.Worker{
+func (m *Manager) CreateWorker(ctx context.Context, mtype string) (*api.Worker, error) {
+	return &api.Worker{
 		ClusterName:       m.clusterName,
 		MachineID:         "i-01e9c47fede75cb9a",
 		MachineName:       "clusterName-worker-e289335e-9579-11e8-b97f-9cb6d0f71293",
@@ -54,8 +55,8 @@ func (m *Manager) CreateWorker(ctx context.Context, mtype string) (*workers.Work
 	}, m.err
 }
 
-func (m *Manager) GetWorker(ctx context.Context, id string) (*workers.Worker, error) {
-	return &workers.Worker{
+func (m *Manager) GetWorker(ctx context.Context, id string) (*api.Worker, error) {
+	return &api.Worker{
 		ClusterName:       m.clusterName,
 		MachineID:         id,
 		MachineName:       "clusterName-worker-e289335e-9579-11e8-b97f-9cb6d0f71293",
@@ -65,9 +66,9 @@ func (m *Manager) GetWorker(ctx context.Context, id string) (*workers.Worker, er
 	}, m.err
 }
 
-func (m *Manager) ListWorkers(ctx context.Context) (*workers.WorkerList, error) {
-	return &workers.WorkerList{
-		Items: []*workers.Worker{
+func (m *Manager) ListWorkers(ctx context.Context) (*api.WorkerList, error) {
+	return &api.WorkerList{
+		Items: []*api.Worker{
 			{
 				ClusterName:       m.clusterName,
 				MachineID:         "i-01e9c47fededccb9a",
@@ -88,8 +89,8 @@ func (m *Manager) ListWorkers(ctx context.Context) (*workers.WorkerList, error) 
 	}, m.err
 }
 
-func (m *Manager) DeleteWorker(ctx context.Context, nodeName, id string) (*workers.Worker, error) {
-	return &workers.Worker{
+func (m *Manager) DeleteWorker(ctx context.Context, nodeName, id string) (*api.Worker, error) {
+	return &api.Worker{
 		ClusterName:       m.clusterName,
 		MachineID:         "i-01e9c47fede75cb9a",
 		MachineName:       "clusterName-worker-e289335e-9579-11e8-b97f-9cb6d0f71293",
@@ -99,8 +100,8 @@ func (m *Manager) DeleteWorker(ctx context.Context, nodeName, id string) (*worke
 	}, m.err
 }
 
-func (m *Manager) ReserveWorker(ctx context.Context, w *workers.Worker) (*workers.Worker, error) {
-	return &workers.Worker{
+func (m *Manager) ReserveWorker(ctx context.Context, w *api.Worker) (*api.Worker, error) {
+	return &api.Worker{
 		ClusterName:       m.clusterName,
 		MachineName:       "clusterName-worker-e289335e-9579-11e8-b97f-9cb6d0f71293",
 		MachineType:       "m4.large",


### PR DESCRIPTION
Move capacity models to a separate package to decrease number of dependencies for API users.