### PR TITLE
SC-29 ⁃ Update helm chart for capacity

### DIFF
--- a/chart/capacity/templates/clusterrolebinding.yaml
+++ b/chart/capacity/templates/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "capacity.serviceAccountName" . }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ template "capacity.name" . }}-nodepod-permissions

--- a/chart/capacity/templates/rolebinding.yaml
+++ b/chart/capacity/templates/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "capacity.serviceAccountName" . }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ template "capacity.name" . }}-configmap-updater


### PR DESCRIPTION
At the moment, clusterrolebinding and rolebinding set permissions for service account in the default namespace. Use Release.Namespace value to fix it.