### PR TITLE
Filter out master nodes from the worker list

### DIFF
--- a/pkg/kubescaler/kubescaler.go
+++ b/pkg/kubescaler/kubescaler.go
@@ -70,6 +70,7 @@ type Kubescaler struct {
 }
 
 func New(opts Options) (*Kubescaler, error) {
+	// TODO: use corev1 client
 	kclient, err := config.GetKubernetesClientSet("", opts.Kubeconfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "build kubernetes client")


### PR DESCRIPTION
At the moment API endpoint for worker list returns as worker nodes as master ones. With this PR capacity filter out master nodes from the list.