### PR TITLE
Update scale up function

### DIFF
--- a/pkg/kubescaler/scaleup.go
+++ b/pkg/kubescaler/scaleup.go
@@ -83,7 +83,7 @@ func isIgnored(pod *corev1.Pod, allowedMachines []*provider.MachineType, current
 func hasMachineFor(machineTypes []*provider.MachineType, pod *corev1.Pod) bool {
 	cpu, mem := getCPUMemForScheduling(pod)
 	for _, m := range machineTypes {
-		if m.CPUResource.Cmp(cpu) >= 0 && m.MemoryResource.Cmp(mem) == 1 {
+		if hasResources(m, cpu, mem) {
 			return true
 		}
 	}
@@ -100,7 +100,7 @@ func bestMachineFor(cpu, mem resource.Quantity, machineTypes []*provider.Machine
 
 	var biggest provider.MachineType
 	for _, m := range provider.SortedMachineTypes(machineTypes) {
-		if m.CPUResource.Cmp(cpu) > -1 && m.MemoryResource.Cmp(mem) == 1 {
+		if hasResources(m, cpu, mem) {
 			return *m, nil
 		}
 		biggest = *m
@@ -153,4 +153,9 @@ func podNames(pods []*corev1.Pod) []string {
 		list[i] = pods[i].Name
 	}
 	return list
+}
+
+func hasResources(m *provider.MachineType, cpu, mem resource.Quantity) bool {
+	// machine.cpu >= requested.cpu && machine.mem >= requested.mem
+	return m.CPUResource.Cmp(cpu) >= 0 && m.MemoryResource.Cmp(mem) >= 0
 }

--- a/pkg/kubescaler/scaleup_test.go
+++ b/pkg/kubescaler/scaleup_test.go
@@ -297,7 +297,7 @@ func TestBestMachineFor(t *testing.T) {
 			cpu:          resource.MustParse("13"),
 			mem:          resource.MustParse("13Mi"),
 			machineTypes: []*provider.MachineType{&machineType13, &machineType42},
-			expectedRes:  machineType42,
+			expectedRes:  machineType13,
 		},
 		{ // TC#6
 			cpu:          resource.MustParse("35"),


### PR DESCRIPTION
Don't ignore machines with memory equal to the requested one. To create a new machine, kubescaler will follow this conditions: `machine.cpu >= requested.cpu && machine.mem >= requested.mem`