### PR TITLE
Add a few scale up strategies for capacity

### DIFF
--- a/apidocs/swagger.json
+++ b/apidocs/swagger.json
@@ -253,9 +253,6 @@
     "Config": {
       "type": "object",
       "properties": {
-        "SupergiantV1Config": {
-          "$ref": "#/definitions/SupergiantV1UserdataVars"
-        },
         "clusterName": {
           "type": "string",
           "x-go-name": "ClusterName"
@@ -301,6 +298,12 @@
         "scanInterval": {
           "type": "string",
           "x-go-name": "ScanInterval"
+        },
+        "strategy": {
+          "$ref": "#/definitions/ScaleUpStrategy"
+        },
+        "supergiantV1Config": {
+          "$ref": "#/definitions/SupergiantV1UserdataVars"
         },
         "userdata": {
           "description": "Userdata is a base64 encoded representation of shell commands or cloud-init directives\nthat applies after the instance starts.\nhttps://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html",
@@ -372,12 +375,16 @@
           "x-go-name": "Name"
         },
         "priceHour": {
-          "type": "integer",
-          "format": "int64",
+          "type": "number",
+          "format": "double",
           "x-go-name": "PriceHour"
         }
       },
       "x-go-package": "github.com/supergiant/capacity/pkg/provider"
+    },
+    "ScaleUpStrategy": {
+      "type": "string",
+      "x-go-package": "github.com/supergiant/capacity/pkg/api"
     },
     "SupergiantV1UserdataVars": {
       "type": "object",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -53,15 +53,33 @@ type Config struct {
 	MachineTypes    []string          `json:"machineTypes"`
 	// TODO: this is hardcoded and isn't used at the moment
 	MaxMachineProvisionTime string            `json:"maxMachineProvisionTime"`
-	IgnoredNodeLabels       map[string]string `json:"ignoredNodeLabels"`
+	IgnoredNodeLabels       map[string]string `json:"ignoredNodeLabels,omitempty"`
 
 	// Userdata is a base64 encoded representation of shell commands or cloud-init directives
 	// that applies after the instance starts.
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
 	Userdata string `json:"userdata"`
-
-	SupergiantV1Config *SupergiantV1UserdataVars
+	// SupergiantV1Config holds configuration for userdata parameters used to provision Supergiant v1 nodes
+	// DEPRECATED: sg v1 has no support.
+	SupergiantV1Config *SupergiantV1UserdataVars `json:"supergiantV1Config,omitempty"`
+	// Strategy is a way capacity determines a machine to create for unscheduled pods. Capacity recognizes 'bigBox',
+	// 'smallCPUBox' and 'smallMemBox' ones. The 'bigBox' one is used by default.
+	Strategy ScaleUpStrategy `json:"strategy"`
 }
+
+type ScaleUpStrategy string
+
+var (
+	// BigBox is a strategy for capacity. It's used to determine a machine type that fits most of the unscheduled pods at once.
+	// The one with the lower price and higher amount of CPU and memory will be created.
+	BigBox ScaleUpStrategy = "bigBox"
+	// SmallCPUBox is a strategy for capacity. It's used to determine a machine type for the smallest pod at once.
+	// The one with the lower price and higher amount of CPU and memory will be created. Has priority by CPU.
+	SmallCPUBox ScaleUpStrategy = "smallCPUBox"
+	// SmallMemBox is a strategy for capacity. It's used to determine a machine type for the smallest pod at once.
+	// The one with the lower price and higher amount of memory and CPU will be created. Has priority by memory.
+	SmallMemBox ScaleUpStrategy = "smallMemBox"
+)
 
 type SupergiantV1UserdataVars struct {
 	MasterPrivateAddr string `json:"masterPrivateAddr"`

--- a/pkg/kubescaler/config.go
+++ b/pkg/kubescaler/config.go
@@ -52,12 +52,13 @@ func NewConfigManager(file persistentfile.Interface) (*ConfigManager, error) {
 
 	// If error has happen or content is simply empty - dont try to unmarshall it
 	if err != nil || len(raw) == 0 {
-		log.Warnf("Read config %v", err)
+		log.Warnf("read %s config: %s", file.Info(), err)
 	} else {
 		// TODO: use codec to support more formats
 		if err = json.Unmarshal(raw, &conf); err != nil {
 			return nil, errors.Wrap(err, "decode config")
 		}
+		log.Infof("found config: %+v", conf)
 	}
 
 	return &ConfigManager{

--- a/pkg/kubescaler/kubescaler.go
+++ b/pkg/kubescaler/kubescaler.go
@@ -207,7 +207,7 @@ func (s *Kubescaler) RunOnce(currentTime time.Time) error {
 		if cfg.WorkersCountMax > 0 && cfg.WorkersCountMax > len(rss.workerList.Items) {
 			var scaled bool
 			// try to scale up the cluster. In case of success no need to scale down
-			scaled, err = s.scaleUp(rss.unscheduledPods, allowedMachineTypes, currentTime)
+			scaled, err = s.scaleUp(rss.unscheduledPods, allowedMachineTypes, cfg.Strategy, currentTime)
 			if err != nil {
 				return errors.Wrap(err, "scale up")
 			}

--- a/pkg/kubescaler/scaleup_test.go
+++ b/pkg/kubescaler/scaleup_test.go
@@ -24,12 +24,25 @@ var (
 	trueVar     = true
 	errFake     = errors.New("fake error")
 
+	resource05   = resource.MustParse("0.5")
 	resource1    = resource.MustParse("1")
-	resource1Mi  = resource.MustParse("1Mi")
 	resource2    = resource.MustParse("2")
+	resource3    = resource.MustParse("3")
+	resource4    = resource.MustParse("4")
+	resource8    = resource.MustParse("8")
+	resource1Mi  = resource.MustParse("1Mi")
 	resource2Mi  = resource.MustParse("2Mi")
 	resource42   = resource.MustParse("42")
 	resource42Mi = resource.MustParse("42Mi")
+	resource2G   = resource.MustParse("2G")
+	resource4G   = resource.MustParse("4G")
+	resource8G   = resource.MustParse("8G")
+	resource8Gi  = resource.MustParse("8Gi")
+	resource16G  = resource.MustParse("16G")
+	resource16Gi = resource.MustParse("16Gi")
+	resource32G  = resource.MustParse("32G")
+	resource32Gi = resource.MustParse("32Gi")
+	resource64Gi = resource.MustParse("64Gi")
 
 	vmPrice1CPU1Mem1 = provider.MachineType{
 		Name:           "Price1CPU1Mem1",
@@ -66,6 +79,43 @@ var (
 		CPUResource:    resource42,
 		MemoryResource: resource42Mi,
 		PriceHour:      42,
+	}
+
+	vmM4LargePrice02CPU2Mem4G = provider.MachineType{
+		Name:           "m4.large",
+		CPUResource:    resource2,
+		MemoryResource: resource8Gi,
+		PriceHour:      0.1,
+	}
+	vmM4xLargePrice02CPU2Mem4G = provider.MachineType{
+		Name:           "m4.xlarge",
+		CPUResource:    resource4,
+		MemoryResource: resource16Gi,
+		PriceHour:      0.2,
+	}
+	vmM42xLargePrice02CPU2Mem4G = provider.MachineType{
+		Name:           "m4.2xlarge",
+		CPUResource:    resource8,
+		MemoryResource: resource32Gi,
+		PriceHour:      0.4,
+	}
+	vmR5LargePrice02CPU2Mem4G = provider.MachineType{
+		Name:           "r5.large",
+		CPUResource:    resource2,
+		MemoryResource: resource16Gi,
+		PriceHour:      0.126,
+	}
+	vmR5xLargePrice02CPU2Mem4G = provider.MachineType{
+		Name:           "r5.xlarge",
+		CPUResource:    resource4,
+		MemoryResource: resource32Gi,
+		PriceHour:      0.252,
+	}
+	vmR52xLargePrice02CPU2Mem4G = provider.MachineType{
+		Name:           "r5.2xlarge",
+		CPUResource:    resource8,
+		MemoryResource: resource64Gi,
+		PriceHour:      0.504,
 	}
 
 	resourceList1CPU1Mi = corev1.ResourceList{
@@ -197,6 +247,207 @@ var (
 			},
 		},
 	}
+
+	pod05CPU2GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod05CPU2GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource05,
+							"memory": resource2G,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod05CPU4GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod05CPU4GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource05,
+							"memory": resource4G,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod1CPU4GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod1CPU4GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource1,
+							"memory": resource4G,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod1CPU8GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod1CPU8GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource1,
+							"memory": resource8G,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod2CPU8GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod2CPU8GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource2,
+							"memory": resource8G,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod2CPU16GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod2CPU16GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource2,
+							"memory": resource16G,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod4CPU16GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod4CPU16GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource4,
+							"memory": resource16G,
+						},
+					},
+				},
+			},
+		},
+	}
+	pod3CPU32GMem = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod3CPU32GMem",
+			CreationTimestamp: metav1.Time{Time: currentTime.Add(-time.Hour)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "Deployment",
+					Controller: &trueVar,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: NodeReadyName,
+			Containers: []corev1.Container{
+				{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"cpu":    resource3,
+							"memory": resource32G,
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 type fakeProvider struct {
@@ -254,8 +505,92 @@ func TestKubescalerScaleUp(t *testing.T) {
 			workerManager: fake.NewManager(tc.providerErr),
 		}
 
-		_, err = ks.scaleUp(tc.pods, allowedMachines, currentTime)
+		_, err = ks.scaleUp(tc.pods, allowedMachines, "", currentTime)
 		require.Equalf(t, tc.expectedErr, errors.Cause(err), "TC#%d", i+1)
+	}
+
+}
+
+func TestMachineToScale_SmallCPUBox(t *testing.T) {
+	tcs := []struct {
+		name        string
+		pods        []*corev1.Pod
+		expectedVM  provider.MachineType
+		expectedErr error
+	}{
+		{
+			name:       "1 2cpu/8GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod2CPU8GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "1 2cpu/16GB pod, expect r5.large",
+			pods:       []*corev1.Pod{&pod2CPU16GMem},
+			expectedVM: vmR5LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "1 4cpu/16GB pod, expect r5.xlarge",
+			pods:       []*corev1.Pod{&pod4CPU16GMem},
+			expectedVM: vmM4xLargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "1 3cpu/32GB pod, expect r5.xlarge",
+			pods:       []*corev1.Pod{&pod3CPU32GMem},
+			expectedVM: vmR5xLargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "2 2cpu/8GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod2CPU8GMem, &pod2CPU8GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "2 2cpu/16GB pod, expect r5.large",
+			pods:       []*corev1.Pod{&pod2CPU16GMem, &pod2CPU16GMem},
+			expectedVM: vmR5LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "3 2cpu/8GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod2CPU8GMem, &pod2CPU8GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "1 1cpu/4GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod1CPU4GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "1 1cpu/8GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod1CPU8GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "1 0.5cpu/2GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod05CPU2GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "1 0.5cpu/4GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod05CPU4GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "2 1cpu/4GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod1CPU4GMem, &pod1CPU4GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+		{
+			name:       "2 1cpu/8GB pod, expect m4.large",
+			pods:       []*corev1.Pod{&pod1CPU8GMem, &pod1CPU8GMem},
+			expectedVM: vmM4LargePrice02CPU2Mem4G,
+		},
+	}
+
+	vmTypes := []*provider.MachineType{&vmM4LargePrice02CPU2Mem4G, &vmM4xLargePrice02CPU2Mem4G, &vmM42xLargePrice02CPU2Mem4G,
+		&vmR5LargePrice02CPU2Mem4G, &vmR5xLargePrice02CPU2Mem4G, &vmR52xLargePrice02CPU2Mem4G}
+	for _, tc := range tcs {
+		mtype, err := machineToScale(tc.pods, vmTypes, api.SmallCPUBox)
+		require.Equalf(t, tc.expectedErr, errors.Cause(err), "TC: %s: check error", tc.name)
+		require.Equalf(t, tc.expectedVM, mtype, "TC: %s: check machine type", tc.name)
 	}
 
 }


### PR DESCRIPTION
Strategy is a way capacity determines a machine to create for unscheduled pods. Capacity will recognize 'bigBox', 'smallCPUBox' and 'smallMemBox' ones. The 'bigBox' one is used by default.
